### PR TITLE
Improve Japanese readability

### DIFF
--- a/articles/event-hubs/event-hubs-programming-guide.md
+++ b/articles/event-hubs/event-hubs-programming-guide.md
@@ -21,9 +21,9 @@
 
 ## イベント発行元
 
-イベントは Event Hub に HTTP POST と AMQP 1.0 接続のいずれかを利用して送信されます。何をいつ利用するかは、対処される特定のシナリオによって決まります。AMQP 1.0 接続は Service Bus の仲介型接続として課金され、メッセージ量が常に多く、待ち時間要件の低いシナリオに適しています。固定のメッセージング チャンネルが提供されるためです。
+イベントは、HTTP POST か AMQP 1.0 接続のいずれかを利用して Event Hub に送信されます。何をいつ利用するかは、解決対象の具体的なシナリオによります。AMQP 1.0 接続は Service Bus の仲介型接続として課金され、頻繁にメッセージ量が多くなり、低遅延の要件があるシナリオに適しています。固定のメッセージング チャンネルが提供されるためです。
 
-Event Hubs は [NamespaceManager](https://msdn.microsoft.com/library/azure/microsoft.servicebus.namespacemanager.aspx) クラスで作成され、管理されます。.NET 管理 API を使用するとき、Event Hubs にデータを発行するためのプライマリ コンストラクトは [EventHubClient](https://msdn.microsoft.com/library/azure/microsoft.servicebus.messaging.eventhubclient.aspx) クラスと [EventData](https://msdn.microsoft.com/library/azure/microsoft.servicebus.messaging.eventdata.aspx) クラスになります。[EventHubClient](https://msdn.microsoft.com/library/azure/microsoft.servicebus.messaging.eventhubclient.aspx) は、イベントが Event Hub に送信される AMQP 通信チャンネルを提供します。[EventData](https://msdn.microsoft.com/library/azure/microsoft.servicebus.messaging.eventdata.aspx) クラスはイベントを表し、Event Hub にメッセージを発行するために使用されます。このクラスには、本文、いくつかのメタデータ、イベントに関するヘッダー情報が含まれます。その他のプロパティは [EventData](https://msdn.microsoft.com/library/azure/microsoft.servicebus.messaging.eventdata.aspx) オブジェクトに追加され、Event Hub に渡されます。
+Event Hubs は [NamespaceManager](https://msdn.microsoft.com/library/azure/microsoft.servicebus.namespacemanager.aspx) クラスで作成され、管理されます。.NET のマネージ API を使用する場合、Event Hubs にデータを発行するための主な構成要素は [EventHubClient](https://msdn.microsoft.com/library/azure/microsoft.servicebus.messaging.eventhubclient.aspx) クラスと [EventData](https://msdn.microsoft.com/library/azure/microsoft.servicebus.messaging.eventdata.aspx) クラスになります。[EventHubClient](https://msdn.microsoft.com/library/azure/microsoft.servicebus.messaging.eventhubclient.aspx) は、イベントが Event Hub に送信されるときに使われる AMQP 通信チャンネルを提供します。[EventData](https://msdn.microsoft.com/library/azure/microsoft.servicebus.messaging.eventdata.aspx) クラスはイベントを表し、Event Hub にメッセージを発行するために使用されます。このクラスには、本文、いくつかのメタデータ、イベントに関するヘッダー情報が含まれます。その他のプロパティは [EventData](https://msdn.microsoft.com/library/azure/microsoft.servicebus.messaging.eventdata.aspx) オブジェクトに追加され、Event Hub に渡されます。
 
 ## 作業開始
 
@@ -48,19 +48,19 @@ var description = manager.CreateEventHub("MyEventHub");
 var description = manager.CreateEventHubIfNotExists("MyEventHub");
 ```
 
-[CreateEventHubIfNotExists](https://msdn.microsoft.com/library/azure/microsoft.servicebus.namespacemanager.createeventhubifnotexists.aspx) など、すべての Event Hub 作成操作で、該当する名前空間の**管理**アクセス許可が必要になります。発行元またはコンシューマー アプリケーションのアクセス許可を制限する場合、アクセス許可を制限して資格情報を利用するとき、運用コードでこれらの作成操作呼び出しを回避できます。
+[CreateEventHubIfNotExists](https://msdn.microsoft.com/library/azure/microsoft.servicebus.namespacemanager.createeventhubifnotexists.aspx) など、すべての Event Hub 作成操作で、該当する名前空間の**管理**アクセス許可が必要になります。発行元またはコンシューマー アプリケーションのアクセス許可を制限したい場合、本番のコードでアクセス許可を制限して資格情報を利用するときにこれらの作成操作呼び出しを避けることができます。
 
-[EventHubDescription](https://msdn.microsoft.com/library/azure/microsoft.servicebus.messaging.eventhubdescription.aspx) クラスには、承認規則、メッセージの保有期間、パーティション ID、状態、パスなど、Event Hub の詳細が含まれています。このクラスを使用し、Event Hub でメタデータを更新できます。
+[EventHubDescription](https://msdn.microsoft.com/library/azure/microsoft.servicebus.messaging.eventhubdescription.aspx) クラスには、承認規則、メッセージの保有期間、パーティション ID、状態、パスなど、Event Hub の詳細が含まれています。このクラスを使用し、Event Hub のメタデータを更新できます。
 
 ## Event Hub クライアントの作成
 
-Event Hubs とやり取りするためのプライマリ クラスは [Microsoft.ServiceBus.Messaging.EventHubClient](https://msdn.microsoft.com/library/azure/microsoft.servicebus.messaging.eventhubclient.aspx) です。このクラスは送信機能と受信機能の両方を提供します。次の例のように、[Create](https://msdn.microsoft.com/library/azure/microsoft.servicebus.messaging.eventhubclient.create.aspx) メソッドを利用してこのクラスをインスタンス化できます。
+Event Hubs とやり取りするための主要クラスは [Microsoft.ServiceBus.Messaging.EventHubClient](https://msdn.microsoft.com/library/azure/microsoft.servicebus.messaging.eventhubclient.aspx) です。このクラスは送信機能と受信機能の両方を提供します。次の例のように、[Create](https://msdn.microsoft.com/library/azure/microsoft.servicebus.messaging.eventhubclient.create.aspx) メソッドを利用してこのクラスをインスタンス化できます。
 
 ```
 var client = EventHubClient.Create(description.Path);
 ```
 
-このメソッドは `appSettings` セクションにある App.config ファイルの Service Bus 情報を使用します。Service Bus 接続情報を格納するために使用される `appSettings` XML の例については、[Microsoft.ServiceBus.Messaging.EventHubClient.Create(System.String)](https://msdn.microsoft.com/library/azure/microsoft.servicebus.messaging.eventhubclient.create.aspx) メソッドの文書を参照してください。
+このメソッドは App.config ファイルの `appSettings` セクションにある、Service Bus の接続情報を使用します。Service Bus 接続情報を格納するために使用される `appSettings` XML の例については、[Microsoft.ServiceBus.Messaging.EventHubClient.Create(System.String)](https://msdn.microsoft.com/library/azure/microsoft.servicebus.messaging.eventhubclient.create.aspx) メソッドの文書を参照してください。
 
 接続文字列からクライアントを作成することもできます。この選択肢は Azure worker ロールを使用する場合に効果があります。worker の設定プロパティに文字列を格納できるためです。次に例を示します。
 
@@ -81,35 +81,35 @@ var factory = MessagingFactory.CreateFromConnectionString("your_connection_strin
 var client = factory.CreateEventHubClient("MyEventHub");
 ```
 
-これは重要なことですが、メッセージング ファクトリ インスタンスから作成された追加 [EventHubClient](https://msdn.microsoft.com/library/azure/microsoft.servicebus.messaging.eventhubclient.aspx) オブジェクトで同じ基礎 TCP 接続が再利用されることに注意してください。そのため、これらのオブジェクトでは、スループットにクライアント側の制限があります。[Create](https://msdn.microsoft.com/library/azure/microsoft.servicebus.messaging.eventhubclient.create.aspx) メソッドでは 1 つのメッセージング ファクトリが再利用されます。1 名の送信者から非常に高いスループットを必要とする場合、各メッセージング ファクトリから複数のメッセージ ファクトリと 1 つの [EventHubClient](https://msdn.microsoft.com/library/azure/microsoft.servicebus.messaging.eventhubclient.aspx) オブジェクトを作成できます。
+これは重要なことですが、1 つのメッセージング ファクトリ インスタンスから作成された追加の [EventHubClient](https://msdn.microsoft.com/library/azure/microsoft.servicebus.messaging.eventhubclient.aspx) オブジェクトたちが、同一の内部 TCP 接続を再利用することに注意してください。そのため、これらのオブジェクトでは、スループットにクライアント側の制限があります。[Create](https://msdn.microsoft.com/library/azure/microsoft.servicebus.messaging.eventhubclient.create.aspx) メソッドでは 1 つのメッセージング ファクトリが再利用されます。単一の送信元からの非常に高いスループットを必要とする場合には、複数メッセージング ファクトリを作成して、それぞれのメッセージ ファクトリから 1 つの [EventHubClient](https://msdn.microsoft.com/library/azure/microsoft.servicebus.messaging.eventhubclient.aspx) オブジェクトを作成するようにできます。
 
 ## Event Hub にイベントを送信する
 
-[EventData](https://msdn.microsoft.com/library/azure/microsoft.servicebus.messaging.eventdata.aspx) インスタンスを作成し、それを [Send](https://msdn.microsoft.com/library/azure/microsoft.servicebus.messaging.eventhubclient.send.aspx) メソッドで送信することで Event Hub にイベントを送信します。このメソッドは [EventData](https://msdn.microsoft.com/library/azure/microsoft.servicebus.messaging.eventdata.aspx) インスタンス パラメーターを 1 つ受け取り、それを Event Hub に同期で送信します。
+[EventData](https://msdn.microsoft.com/library/azure/microsoft.servicebus.messaging.eventdata.aspx) インスタンスを作成し、それを [Send](https://msdn.microsoft.com/library/azure/microsoft.servicebus.messaging.eventhubclient.send.aspx) メソッドで送信することで Event Hub にイベントを送信します。このメソッドは [EventData](https://msdn.microsoft.com/library/azure/microsoft.servicebus.messaging.eventdata.aspx) インスタンス パラメーターを 1 つ受け取り、それを Event Hub に同期的に送信します。
 
 ## イベントのシリアル化
 
-[EventData](https://msdn.microsoft.com/library/azure/microsoft.servicebus.messaging.eventdata.aspx) クラスには [オーバーロードされたコンストラクターが 4 つ](https://msdn.microsoft.com/library/azure/microsoft.servicebus.messaging.eventdata.eventdata.aspx)あります。これらのコンストラクターは、オブジェクト、シリアライザー、バイト配列、ストリームなど、さまざまパラメーターを受け取ります。[EventData](https://msdn.microsoft.com/library/azure/microsoft.servicebus.messaging.eventdata.aspx) クラスをインスタンス化し、その後、本文のストリームを設定することもできます。JSON と共に [EventData](https://msdn.microsoft.com/library/azure/microsoft.servicebus.messaging.eventdata.aspx) を使用するとき、**Encoding.UTF8.GetBytes()** を使用し、JSON でエンコードされた文字列のバイト配列を取得できます。
+[EventData](https://msdn.microsoft.com/library/azure/microsoft.servicebus.messaging.eventdata.aspx) クラスには [オーバーロードされたコンストラクターが 4 つ](https://msdn.microsoft.com/library/azure/microsoft.servicebus.messaging.eventdata.eventdata.aspx)あります。これらのコンストラクターは、オブジェクトとシリアライザー、またはバイト配列やストリームといった、さまざまパラメーターを受け取ります。[EventData](https://msdn.microsoft.com/library/azure/microsoft.servicebus.messaging.eventdata.aspx) クラスをインスタンス化し、その後、本文のストリームを設定することもできます。JSON と共に [EventData](https://msdn.microsoft.com/library/azure/microsoft.servicebus.messaging.eventdata.aspx) を使用するときには、JSON でエンコードされた文字列のバイト配列を取得するのに **Encoding.UTF8.GetBytes()** を使用できます。
 
 ## パーティション キー
 
-[EventData](https://msdn.microsoft.com/library/azure/microsoft.servicebus.messaging.eventdata.aspx) クラスには [PartitionKey](https://msdn.microsoft.com/library/azure/microsoft.servicebus.messaging.eventdata.partitionkey.aspx) プロパティがあります。このプロパティを利用すると、送信者はハッシュ関数で処理されてパーティション割り当てを作成する値を指定できます。パーティション キーを利用すると、同じキーのすべてのイベントが Event Hub の同じパーティションに送信されます。共通のパーティション キーにはユーザー セッション ID と一意の送信者 ID が含まれます。[PartitionKey](https://msdn.microsoft.com/library/azure/microsoft.servicebus.messaging.eventdata.partitionkey.aspx) プロパティは任意であり、[Microsoft.ServiceBus.Messaging.EventHubClient.Send(Microsoft.ServiceBus.Messaging.EventData)](https://msdn.microsoft.com/library/azure/microsoft.servicebus.messaging.eventdata.aspx) メソッドまたは [Microsoft.ServiceBus.Messaging.EventHubClient.SendAsync(Microsoft.ServiceBus.Messaging.EventData)](https://msdn.microsoft.com/library/azure/microsoft.servicebus.messaging.eventdata.aspx) メソッドの利用時に指定できます。[PartitionKey](https://msdn.microsoft.com/library/azure/microsoft.servicebus.messaging.eventdata.partitionkey.aspx) 値を指定しない場合、送信されたイベントはラウンドロビン モデルを利用してパーティションに配信されます。
+[EventData](https://msdn.microsoft.com/library/azure/microsoft.servicebus.messaging.eventdata.aspx) クラスには [PartitionKey](https://msdn.microsoft.com/library/azure/microsoft.servicebus.messaging.eventdata.partitionkey.aspx) プロパティがあります。このプロパティを利用して、送信元は、パーティションを割り当てるためにハッシュ化される値を指定できます。パーティション キーを利用することで、同じキーを持つすべてのイベントが Event Hub の同じパーティションに送信されることが保証されます。一般的なパーティション キーには、ユーザー セッション ID や一意な送信元 ID が含まれます。[PartitionKey](https://msdn.microsoft.com/library/azure/microsoft.servicebus.messaging.eventdata.partitionkey.aspx) プロパティは任意であり、[Microsoft.ServiceBus.Messaging.EventHubClient.Send(Microsoft.ServiceBus.Messaging.EventData)](https://msdn.microsoft.com/library/azure/microsoft.servicebus.messaging.eventdata.aspx) メソッドまたは [Microsoft.ServiceBus.Messaging.EventHubClient.SendAsync(Microsoft.ServiceBus.Messaging.EventData)](https://msdn.microsoft.com/library/azure/microsoft.servicebus.messaging.eventdata.aspx) メソッドの利用時に指定できます。[PartitionKey](https://msdn.microsoft.com/library/azure/microsoft.servicebus.messaging.eventdata.partitionkey.aspx) の値を指定しない場合、送信されたイベントはラウンドロビン モデルを利用して各パーティションに配信されます。
 
-## イベントの一括送信操作
+## イベントのバッチ送信処理
 
-イベントを一括送信すると、スループットが劇的に上がります。[SendBatch](https://msdn.microsoft.com/library/azure/microsoft.servicebus.messaging.eventhubclient.sendbatch.aspx) メソッドは [EventData](https://msdn.microsoft.com/library/azure/microsoft.servicebus.messaging.eventdata.aspx) 型の **IEnumerable** パラメーターを受け取り、バッチ全体をアトミック操作として Event Hub に送信します。
+イベントをバッチ送信すると、スループットが劇的に上がります。[SendBatch](https://msdn.microsoft.com/library/azure/microsoft.servicebus.messaging.eventhubclient.sendbatch.aspx) メソッドは [EventData](https://msdn.microsoft.com/library/azure/microsoft.servicebus.messaging.eventdata.aspx) 型の **IEnumerable** パラメーターを受け取り、バッチ全体をアトミック操作として Event Hub に送信します。
 
 ```
 public void SendBatch(IEnumerable<EventData> eventDataList);
 ```
 
-1 回のバッチがイベントの 256 KB 制限を超えてはならないことに注意してください。また、バッチの各メッセージで同じ発行元 ID が使用されます。バッチが最大イベント サイズを超えないようにすることは送信者側の責任となります。超えた場合、クライアントの**送信**エラーが生成されます。
+単一のバッチがイベントの 256 KB 制限を超えてはならないことに注意してください。また、バッチの各メッセージでは同じ発行元 ID が使用されます。バッチが最大イベント サイズを超えないようにすることは送信元の責任となります。超えた場合、クライアント**送信**エラーが生成されます。
 
 ## 非同期送信と大規模送信
 
-Event Hub にイベントを非同期送信することもできます。非同期送信を利用すると、クライアントがイベントを送信する速度が上がります。[Send](https://msdn.microsoft.com/library/azure/microsoft.servicebus.messaging.eventhubclient.send.aspx) メソッドと [SendBatch](https://msdn.microsoft.com/library/azure/microsoft.servicebus.messaging.eventhubclient.sendbatch.aspx) メソッドの両方を [Task](https://msdn.microsoft.com/library/system.threading.tasks.task.aspx) オブジェクトを返す非同期バージョンで利用できます。この手法ではスループットが上がりますが、Event Hubs で調整中でもクライアントはイベントの送信を続けるので、適切に実装されていない場合、クライアントに障害が発生したり、メッセージが失われたりすることがあります。また、クライアントの [RetryPolicy](https://msdn.microsoft.com/library/azure/microsoft.servicebus.messaging.cliententity.retrypolicy.aspx) プロパティを使用し、クライアント再試行オプションを制御できます。
+Event Hub にイベントを非同期送信することもできます。非同期送信を利用すると、クライアントがイベントを送信する速度が上がります。[Send](https://msdn.microsoft.com/library/azure/microsoft.servicebus.messaging.eventhubclient.send.aspx) メソッドと [SendBatch](https://msdn.microsoft.com/library/azure/microsoft.servicebus.messaging.eventhubclient.sendbatch.aspx) メソッドの両方で [Task](https://msdn.microsoft.com/library/system.threading.tasks.task.aspx) オブジェクトを返す非同期バージョンを利用できます。この手法ではスループットが上がりますが、Event Hubs でスロットリングされていてもクライアントがイベントの送信を続けるので、適切に実装されていない場合、クライアントに障害が発生したり、メッセージが失われたりすることがあります。また、クライアントの [RetryPolicy](https://msdn.microsoft.com/library/azure/microsoft.servicebus.messaging.cliententity.retrypolicy.aspx) プロパティを使用し、クライアント側の再試行オプションを制御できます。
 
-## パーティション送信者の作成
+## パーティション送信元の作成
 
 パーティション キーを持つ Event Hub にイベントを送信するのが最も一般的ですが、特定のパーティションにイベントを直接送信することもあります。次に例を示します。
 
@@ -121,18 +121,18 @@ var partitionedSender = client.CreatePartitionedSender(description.PartitionIds[
 
 ## イベント コンシューマー
 
-Event Hubs にはイベント使用のために 2 つの主要モデルが用意されています。ダイレクト レシーバーと [EventProcessorHost](https://msdn.microsoft.com/library/azure/microsoft.servicebus.messaging.eventprocessorhost.aspx) のような上位の抽象化です。ダイレクト レシーバーはコンシューマー グループ内のパーティションの独自のアクセス調整を担当します。
+Event Hubs にはイベント使用のために 2 つの主要モデルが用意されています。ダイレクト レシーバーと [EventProcessorHost](https://msdn.microsoft.com/library/azure/microsoft.servicebus.messaging.eventprocessorhost.aspx) のような上位の抽象構造です。ダイレクト レシーバーは、コンシューマー グループ内のパーティションについて、自前でアクセス調整を行う責任があります。
 
 ### ダイレクト コンシューマー
 
-コンシューマー グループ内のパーティションから読み取るための最も直接的な方法は [EventHubReceiver](https://msdn.microsoft.com/library/azure/microsoft.servicebus.messaging.eventhubreceiver.aspx) クラスを使用することです。このクラスのインスタンスを作成するには、[EventHubConsumerGroup](https://msdn.microsoft.com/library/azure/microsoft.servicebus.messaging.eventhubconsumergroup.aspx) クラスのインスタンスを使用する必要があります。次の例では、コンシューマー グループの受信者を作成するときにパーティション ID を指定する必要があります。
+コンシューマー グループ内の 1 つのパーティションから読み取るための最も直接的な方法は [EventHubReceiver](https://msdn.microsoft.com/library/azure/microsoft.servicebus.messaging.eventhubreceiver.aspx) クラスを使用することです。このクラスのインスタンスを作成するには、[EventHubConsumerGroup](https://msdn.microsoft.com/library/azure/microsoft.servicebus.messaging.eventhubconsumergroup.aspx) クラスのインスタンスを使用する必要があります。次の例では、コンシューマー グループの受信者を作成するときにパーティション ID を指定する必要があります。
 
 ```
 EventHubConsumerGroup group = client.GetDefaultConsumerGroup();
 var receiver = group.CreateReceiver(client.GetRuntimeInformation().PartitionIds[0]);
 ```
 
-[CreateReceiver](https://msdn.microsoft.com/library/azure/microsoft.servicebus.messaging.eventhubconsumergroup.createreceiver.aspx)メソッドには、作成中のリーダーの制御を円滑にするいくつかのオーバーロードがあります。これらのメソッドでは文字列とタイムスタンプのいずれかをオフセットとして指定します。返されたストリームにこの指定したオフセットを含めるか、その後に開始するか指定できます。レシーバーを作成したら、返されたオブジェクトでイベントの受信を開始できます。[Receive](https://msdn.microsoft.com/library/azure/microsoft.servicebus.messaging.eventhubreceiver.receive.aspx) メソッドには、バッチ サイズや待機時間など、操作パラメーターを制御するオーバーロードが 4 つあります。これらのメソッドの非同期バージョンを利用し、コンシューマーのスループットを上げることができます。次に例を示します。
+[CreateReceiver](https://msdn.microsoft.com/library/azure/microsoft.servicebus.messaging.eventhubconsumergroup.createreceiver.aspx)メソッドには、作成されるリーダーの制御を調整するいくつかのオーバーロードがあります。これらのメソッドでは文字列とタイムスタンプのいずれかをオフセットとして指定します。返されたストリームにこの指定したオフセットを含めるか、その後ろから開始するかを指定できます。レシーバーを作成したら、そのレシーバーでイベントの受信を開始できます。[Receive](https://msdn.microsoft.com/library/azure/microsoft.servicebus.messaging.eventhubreceiver.receive.aspx) メソッドには、バッチ サイズや待機時間など、受信処理のパラメーターを制御するオーバーロードが 4 つあります。これらのメソッドの非同期バージョンを利用し、コンシューマーのスループットを上げることができます。次に例を示します。
 
 ```
 bool receive = true;
@@ -146,13 +146,13 @@ while(receive)
 }
 ```
 
-特定のパーティションについては、メッセージはそれが Event Hub に送信された順序で受信されます。オフセットはパーティションのメッセージ識別に使用される文字列トークンです。
+1 つの特定のパーティションについては、メッセージは Event Hub に送信された順序で受信されます。オフセットはパーティション内でのメッセージ識別に使用される文字列トークンです。
 
-いかなるタイミングでも、コンシューマー グループ内の 1 つのパーティションに 5 つ以上のリーダーを同時接続することはできないことに注意してください。リーダーが接続または切断されると、そのセッションは数分間アクティブの状態を維持し、それから切断がサービスにより認識されることがあります。その間にパーティションに再接続すると、失敗することがあります。Event Hubs のダイレクト レシーバーの完全な記述例については、「[Service Bus Event Hubs Direct Receivers](https://code.msdn.microsoft.com/Event-Hub-Direct-Receivers-13fa95c6)」サンプルを参照してください。
+いかなるタイミングでも、コンシューマー グループ内の 1 つのパーティションに 5 つ以上のリーダーを同時接続することはできないことに注意してください。リーダーが接続または切断された場合、サービスが切断を認識するまで、セッションが数分間アクティブな状態のままになることがあります。その間にパーティションに再接続すると、失敗することがあります。Event Hubs のダイレクト レシーバーの完全な記述例については、「[Service Bus Event Hubs Direct Receivers](https://code.msdn.microsoft.com/Event-Hub-Direct-Receivers-13fa95c6)」サンプルを参照してください。
 
 ### イベント プロセッサ ホスト
 
-[EventProcessorHost](https://msdn.microsoft.com/library/azure/microsoft.servicebus.messaging.eventprocessorhost.aspx)クラスは Event Hubs からのデータを処理します。.NET プラットフォームでのイベント リーダーを作成するときに、この実装を使用する必要があります。[EventProcessorHost](https://msdn.microsoft.com/library/azure/microsoft.servicebus.messaging.eventprocessorhost.aspx) はイベント プロセッサ実装のためにスレッドセーフでマルチプロセスの安全なランタイム環境を提供します。さらに、その環境では、チックポイント処理とパーティション リースの管理が提供されます。
+[EventProcessorHost](https://msdn.microsoft.com/library/azure/microsoft.servicebus.messaging.eventprocessorhost.aspx)クラスは Event Hubs からのデータを処理します。.NET プラットフォームでのイベント リーダーを作成するときには、この実装を使用すべきです。[EventProcessorHost](https://msdn.microsoft.com/library/azure/microsoft.servicebus.messaging.eventprocessorhost.aspx) はイベント プロセッサ実装のためにスレッドセーフでマルチプロセスの安全なランタイム環境を提供します。さらに、その環境では、チックポイント処理とパーティション リースの管理が提供されます。
 
 [EventProcessorHost](https://msdn.microsoft.com/library/azure/microsoft.servicebus.messaging.eventprocessorhost.aspx) クラスを使用するために、[IEventProcessor](https://msdn.microsoft.com/library/azure/microsoft.servicebus.messaging.ieventprocessor.aspx) を実装できます。このインターフェイスには 3 つのメソッドが含まれています。
 
@@ -168,7 +168,7 @@ while(receive)
 
 時間と共に、均衡が確立されます。この動的機能により、スケールアップとスケールダウンの両方で、CPU に基づく自動スケールがコンシューマーに適用されます。Event Hubs にはメッセージ カウントの直接的概念がないため、平均的な CPU 利用率が、多くの場合、バックエンドまたはコンシューマー スケールを測定する最良のメカニズムとなります。発行元がコンシューマーが処理できる数を超えたイベントを発行し始めた場合、コンシューマーの CPU 増加を利用し、worker インスタンス カウントを自動拡張できます。
 
-[EventProcessorHost](https://msdn.microsoft.com/library/azure/microsoft.servicebus.messaging.eventprocessorhost.aspx) クラスも Azure ストレージ ベースのチェックポイント処理メカニズムを実装します。このメカニズムはパーティション基準でオフセットを格納します。そのため、各コンシューマーは前のコンシューマーからの最後のチェックポイントを判断できます。パーティションはリース経由でノード間を移動するため、これは負荷移動を円滑にする同期メカニズムとなります。
+[EventProcessorHost](https://msdn.microsoft.com/library/azure/microsoft.servicebus.messaging.eventprocessorhost.aspx) クラスは、Azure ストレージ ベースのチェックポイント処理メカニズムも実装します。このメカニズムはパーティションごとにオフセットを保存します。そのため、各コンシューマーは前回のコンシューマーが保存した内容から、最後のチェックポイントを判断できます。パーティションがリースによってノード間を移動するにつれて、負荷移動を円滑にする同期メカニズムとなります。
 
 ## 発行元失効
 


### PR DESCRIPTION
* Reorder words to clarify their relationship (or causes misreading).
* Change word for "should" because it must be distinct from "must" in technical document.
* Change words to feel more natural.