### PR TITLE
Fixing Mistranslation

### DIFF
--- a/articles/automation/automation-first-runbook-graphical.md
+++ b/articles/automation/automation-first-runbook-graphical.md
@@ -28,7 +28,7 @@
 
 このチュートリアルを最後まで行うには、以下のものが必要です。
 
--	として機能します。まだお持ちでない場合は、[MSDN サブスクライバーの特典を有効にする](https://azure.microsoft.com/pricing/member-offers/msdn-benefits-details/)か、<a href="/pricing/free-account/" target="_blank">[無料アカウントにサインアップ](https://azure.microsoft.com/free/)してください。
+-	Azure サブスクリプション。まだお持ちでない場合は、[MSDN サブスクライバーの特典を有効にする](https://azure.microsoft.com/pricing/member-offers/msdn-benefits-details/)か、<a href="/pricing/free-account/" target="_blank">[無料アカウントにサインアップ](https://azure.microsoft.com/free/)してください。
 -	[Azure 実行アカウント](automation-sec-configure-azure-runas-account.md)。Runbook の保存と Azure リソースの認証に使用します。このアカウントには、仮想マシンを開始および停止するアクセス許可が必要です。
 -	Azure 仮想マシン。マシンを停止して起動するので、運用環境のものは使用しないでください。
 

--- a/articles/automation/automation-first-runbook-textual-powershell.md
+++ b/articles/automation/automation-first-runbook-textual-powershell.md
@@ -26,7 +26,7 @@
 
 このチュートリアルを最後まで行うには、以下のものが必要です。
 
--	として機能します。まだお持ちでない場合は、[MSDN サブスクライバーの特典を有効にする](https://azure.microsoft.com/pricing/member-offers/msdn-benefits-details/)か、<a href="/pricing/free-account/" target="_blank">[無料アカウントにサインアップ](https://azure.microsoft.com/free/)してください。
+-	Azure サブスクリプション。まだお持ちでない場合は、[MSDN サブスクライバーの特典を有効にする](https://azure.microsoft.com/pricing/member-offers/msdn-benefits-details/)か、<a href="/pricing/free-account/" target="_blank">[無料アカウントにサインアップ](https://azure.microsoft.com/free/)してください。
 -	[Automation アカウント](automation-security-overview.md)。Runbook の保存と Azure リソースの認証に使用します。このアカウントには、仮想マシンを開始および停止するアクセス許可が必要です。
 -	Azure 仮想マシン。マシンを停止して起動するので、運用環境のものは使用しないでください。
 

--- a/articles/automation/automation-first-runbook-textual.md
+++ b/articles/automation/automation-first-runbook-textual.md
@@ -26,7 +26,7 @@
 
 このチュートリアルを最後まで行うには、以下のものが必要です。
 
--	として機能します。まだお持ちでない場合は、[MSDN サブスクライバーの特典を有効にする](https://azure.microsoft.com/pricing/member-offers/msdn-benefits-details/)か、<a href="/pricing/free-account/" target="_blank">[無料アカウントにサインアップ](https://azure.microsoft.com/free/)してください。
+-	Azure サブスクリプション。まだお持ちでない場合は、[MSDN サブスクライバーの特典を有効にする](https://azure.microsoft.com/pricing/member-offers/msdn-benefits-details/)か、<a href="/pricing/free-account/" target="_blank">[無料アカウントにサインアップ](https://azure.microsoft.com/free/)してください。
 -	[Automation アカウント](automation-security-overview.md)。Runbook の保存と Azure リソースの認証に使用します。このアカウントには、仮想マシンを開始および停止するアクセス許可が必要です。
 -	Azure 仮想マシン。マシンを停止して起動するので、運用環境のものは使用しないでください。
 


### PR DESCRIPTION
`Azure subscription` is `Azure サブスクリプション` in Japanese.
(`として機能します` means like `It will function as ...`.)